### PR TITLE
Fixed wrong return type in docs.

### DIFF
--- a/src/main/java/com/zeoldcraft/skcompat/SKWorldGuard.java
+++ b/src/main/java/com/zeoldcraft/skcompat/SKWorldGuard.java
@@ -1217,7 +1217,7 @@ public class SKWorldGuard {
 
 		@Override
 		public String docs() {
-			return "void {[world], name} Check if a given region exists.";
+			return "boolean {[world], name} Check if a given region exists.";
 		}
 
 		@Override


### PR DESCRIPTION
sk_region_exists() returns a boolean, not void.
