### PR TITLE
 Update skcb_paste() and sk_setblock()

### DIFF
--- a/SKCompat-bundle/pom.xml
+++ b/SKCompat-bundle/pom.xml
@@ -32,12 +32,13 @@
 		<dependency>
 			<groupId>com.sk89q.worldedit</groupId>
 			<artifactId>worldedit-core</artifactId>
-			<version>6.0.2-SNAPSHOT</version>
+			<version>6.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q.worldguard</groupId>
 			<artifactId>worldguard-legacy</artifactId>
-			<version>6.1.3-SNAPSHOT</version>
+			<version>6.2</version>
+			<!-- Note that depending on API changes later than 6.2 may preclude support for MC 1.7.10 - 1.11.2. -->
 		</dependency>
 	</dependencies>
 

--- a/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/SKPlayer.java
+++ b/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/SKPlayer.java
@@ -4,12 +4,15 @@ import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.StaticLayer;
+import com.sk89q.util.StringUtil;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.internal.cui.CUIEvent;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.World;
 
+import java.nio.charset.Charset;
 import java.util.UUID;
 
 /**
@@ -25,8 +28,9 @@ public class SKPlayer extends SKCommandSender {
 
 	@Override
 	public World getWorld() {
+		String worldName = player.getWorld().getName();
 		for (World w : WorldEdit.getInstance().getServer().getWorlds()) {
-			if (w.getName().equals(player.getWorld().getName())) {
+			if (w.getName().equals(worldName)) {
 				return w;
 			}
 		}
@@ -94,5 +98,15 @@ public class SKPlayer extends SKCommandSender {
 	@Override
 	public void setLocation(MCLocation loc) {
 		player.teleport(loc);
+	}
+
+	@Override
+	public void dispatchCUIEvent(CUIEvent event) {
+		String[] params = event.getParameters();
+		String send = event.getTypeId();
+		if (params.length > 0) {
+			send = send + "|" + StringUtil.joinString(params, "|");
+		}
+		player.sendPluginMessage("WECUI", send.getBytes(Charset.forName("UTF-8")));
 	}
 }


### PR DESCRIPTION
- Improves compatibility with plugins overriding WE and has better future proofing by using the API as defined within the command.
- Fixes a large operation delay on FAWE by using editSession.flushQueue() like the commands do.
- Fixes string based pattern input for sk_setblock().
- Fix WE CUI update when using the "select" option in skcb_paste().

This might not be exactly how it should be done, but to keep things simple and get it done I mostly ported over the command for pasting. If nothing else it gives someone a jumping off point if they want to make further improvements. The other 3 fixes are really nice, though.

One thing that needs to be decided later, though, is if these two operations should be added to a player's edit history. Right now they aren't.