### PR TITLE
Add sk_register_flag()

### DIFF
--- a/CHWorldEdit/dependency-reduced-pom.xml
+++ b/CHWorldEdit/dependency-reduced-pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>CHWorldEdit</artifactId>
-  <version>3.1.2</version>
+  <version>3.1.3</version>
   <build>
     <plugins>
       <plugin>

--- a/CHWorldEdit/pom.xml
+++ b/CHWorldEdit/pom.xml
@@ -10,13 +10,13 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>CHWorldEdit</artifactId>
-	<version>3.1.2</version>
+	<version>3.1.3</version>
 
 	<dependencies>
 		<dependency>
 			<groupId>io.github.jbaero</groupId>
 			<artifactId>SKCompat</artifactId>
-			<version>3.1.2</version>
+			<version>3.1.3</version>
 		</dependency>
 	</dependencies>
 

--- a/CHWorldGuard/dependency-reduced-pom.xml
+++ b/CHWorldGuard/dependency-reduced-pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>CHWorldGuard</artifactId>
-  <version>3.1.2</version>
+  <version>3.1.3</version>
   <build>
     <plugins>
       <plugin>

--- a/CHWorldGuard/pom.xml
+++ b/CHWorldGuard/pom.xml
@@ -10,13 +10,13 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>CHWorldGuard</artifactId>
-	<version>3.1.2</version>
+	<version>3.1.3</version>
 
 	<dependencies>
 		<dependency>
 			<groupId>io.github.jbaero</groupId>
 			<artifactId>SKCompat</artifactId>
-			<version>3.1.2</version>
+			<version>3.1.3</version>
 		</dependency>
 	</dependencies>
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ NOTE: CHWorldEdit provides functions for WorldEdit. CHWorldGuard provides functi
 **sk_region_addmember(region, [world], [member(s)])** Add member(s) to a region.<br>
 **sk_region_remmember(region, [world], [member(s)])** Remove member(s) from a region.<br>
 **sk_region_members(region, world)** Returns an array of members of this region.<br>
+**sk_register_flag(name, type)** Registers a new flag (on startup only). Type must be BOOLEAN, DOUBLE, INTEGER, or STRING.<br>
 **sk_region_flag(world, region, flagName, flagValue, [group])** Add/change/remove flag in a region.<br>
 **sk_region_check_flag(locationArray, flagName, [player])** Check state of selected flag in defined location.<br>
 **sk_region_flags(region, world)** Returns an associative array with the flags of the region.<br>

--- a/SKCompat-bundle/pom.xml
+++ b/SKCompat-bundle/pom.xml
@@ -10,12 +10,12 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>SKCompat</artifactId>
-	<version>3.1.2</version>
+	<version>3.1.3</version>
 
 	<repositories>
 		<repository>
-			<id>sk89q-maven</id>
-			<url>http://maven.sk89q.com/repo</url>
+			<id>enginehub-maven</id>
+			<url>https://maven.enginehub.org/repo/</url>
 		</repository>
 		<repository>
 			<id>spigot-repo</id>
@@ -32,12 +32,12 @@
 		<dependency>
 			<groupId>com.sk89q.worldedit</groupId>
 			<artifactId>worldedit-bukkit</artifactId>
-			<version>7.1.0-SNAPSHOT</version>
+			<version>7.2.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q.worldguard</groupId>
 			<artifactId>worldguard-bukkit</artifactId>
-			<version>7.0.1-SNAPSHOT</version>
+			<version>7.0.4</version>
 		</dependency>
 	</dependencies>
 

--- a/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/CHWorldEdit.java
+++ b/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/CHWorldEdit.java
@@ -25,7 +25,6 @@ import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.ObjectGenerator;
-import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.*;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.environments.Environment;
@@ -409,7 +408,7 @@ public class CHWorldEdit {
 			}
 
 			if(args.length == 2) {
-				CArray options = Static.getArray(args[1], t);
+				CArray options = ArgumentValidation.getArray(args[1], t);
 				if (options.containsKey("entities")) {
 					entities = ArgumentValidation.getBooleanObject(options.get("entities", t), t);
 				}
@@ -538,16 +537,16 @@ public class CHWorldEdit {
 			MCCommandSender sender = null;
 			switch (args.length) {
 				case 3:
-					xaxis = Static.getInt32(args[1], t);
-					zaxis = Static.getInt32(args[2], t);
+					xaxis = ArgumentValidation.getInt32(args[1], t);
+					zaxis = ArgumentValidation.getInt32(args[2], t);
 				case 1:
-					yaxis = Static.getInt32(args[0], t);
+					yaxis = ArgumentValidation.getInt32(args[0], t);
 					break;
 				case 4:
-					xaxis = Static.getInt32(args[2], t);
-					zaxis = Static.getInt32(args[3], t);
+					xaxis = ArgumentValidation.getInt32(args[2], t);
+					zaxis = ArgumentValidation.getInt32(args[3], t);
 				case 2:
-					yaxis = Static.getInt32(args[1], t);
+					yaxis = ArgumentValidation.getInt32(args[1], t);
 					sender = SKWorldEdit.GetPlayer(args[0], t);
 					break;
 			}
@@ -603,7 +602,7 @@ public class CHWorldEdit {
 				sender = SKWorldEdit.GetPlayer(args[0], t);
 			}
 			if (args.length >= 2) {
-				CArray options = Static.getArray(args[1], t);
+				CArray options = ArgumentValidation.getArray(args[1], t);
 				if (options.containsKey("airless")) {
 					airless = ArgumentValidation.getBooleanObject(options.get("airless", t), t);
 				}

--- a/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/CHWorldGuard.java
+++ b/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/CHWorldGuard.java
@@ -26,6 +26,7 @@ import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.abstraction.bukkit.BukkitMCOfflinePlayer;
 import com.laytonsmith.annotations.api;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
 import com.laytonsmith.core.ObjectGenerator;
 import com.laytonsmith.core.Static;
@@ -142,7 +143,7 @@ public class CHWorldGuard {
 			int index = -1;
 
 			if (args.length == 3) {
-				index = Static.getInt32(args[2], t);
+				index = ArgumentValidation.getInt32(args[2], t);
 			}
 
 			int maxIndex = 5;
@@ -688,19 +689,19 @@ public class CHWorldGuard {
 						double z = 0;
 
 						if (!point.inAssociativeMode()) {
-							x = Static.getNumber(point.get(0, t), t);
-							y = Static.getNumber(point.get(1, t), t);
-							z = Static.getNumber(point.get(2, t), t);
+							x = ArgumentValidation.getNumber(point.get(0, t), t);
+							y = ArgumentValidation.getNumber(point.get(1, t), t);
+							z = ArgumentValidation.getNumber(point.get(2, t), t);
 						}
 
 						if (point.containsKey("x")) {
-							x = Static.getNumber(point.get("x", t), t);
+							x = ArgumentValidation.getNumber(point.get("x", t), t);
 						}
 						if (point.containsKey("y")) {
-							y = Static.getNumber(point.get("y", t), t);
+							y = ArgumentValidation.getNumber(point.get("y", t), t);
 						}
 						if (point.containsKey("z")) {
-							z = Static.getNumber(point.get("z", t), t);
+							z = ArgumentValidation.getNumber(point.get("z", t), t);
 						}
 
 						vertices.add(BlockVector3.at(x, y, z));
@@ -2056,13 +2057,13 @@ public class CHWorldGuard {
 					world = Static.getServer().getWorld(m.getWorld().getName());
 				}
 
-				priority = Static.getInt32(args[1], t);
+				priority = ArgumentValidation.getInt32(args[1], t);
 
 			} else {
 				region = args[1].val();
 				world = Static.getServer().getWorld(args[0].val());
 
-				priority = Static.getInt32(args[2], t);
+				priority = ArgumentValidation.getInt32(args[2], t);
 			}
 
 			if (world == null) {

--- a/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/SKCommandSender.java
+++ b/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/SKCommandSender.java
@@ -21,6 +21,8 @@ import com.sk89q.worldedit.util.formatting.text.Component;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockState;
 
+import java.util.Locale;
+
 /**
  * @author jb_aero
  */
@@ -102,6 +104,11 @@ public abstract class SKCommandSender extends AbstractPlayerActor implements Ses
 	@Override
 	public BlockBag getInventoryBlockBag() {
 		return new ConsoleBlockBag();
+	}
+
+	@Override
+	public Locale getLocale() {
+		return WorldEdit.getInstance().getConfiguration().defaultLocale;
 	}
 
 	private static class ConsoleBlockBag extends BlockBag {

--- a/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/SKPlayer.java
+++ b/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/SKPlayer.java
@@ -13,10 +13,12 @@ import com.sk89q.worldedit.blocks.BaseItemStack;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.util.HandSide;
 import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.util.formatting.component.TextUtils;
 import com.sk89q.worldedit.world.World;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -106,5 +108,10 @@ public class SKPlayer extends SKCommandSender {
 	@Override
 	public void dispatchCUIEvent(CUIEvent event) {
 		BukkitAdapter.adapt((org.bukkit.entity.Player) player.getHandle()).dispatchCUIEvent(event);
+	}
+
+	@Override
+	public Locale getLocale() {
+		return TextUtils.getLocaleByMinecraftTag(((org.bukkit.entity.Player) player.getHandle()).getLocale());
 	}
 }

--- a/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/SKWorldGuard.java
+++ b/SKCompat-bundle/src/main/java/io/github/jbaero/skcompat/SKWorldGuard.java
@@ -1,9 +1,11 @@
 package io.github.jbaero.skcompat;
 
+import com.laytonsmith.PureUtilities.Common.StringUtils;
 import com.laytonsmith.abstraction.MCLocation;
 import com.laytonsmith.abstraction.MCPlayer;
 import com.laytonsmith.abstraction.MCWorld;
 import com.laytonsmith.core.constructs.Target;
+import com.laytonsmith.core.exceptions.CRE.CREIllegalArgumentException;
 import com.laytonsmith.core.exceptions.CRE.CREPluginInternalException;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector2;
@@ -11,8 +13,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.Flag;
-import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.*;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
@@ -90,7 +91,29 @@ public class SKWorldGuard {
 		}
 		return foundFlag;
 	}
-	
+
+	private enum FlagType {
+		BOOLEAN(BooleanFlag.class),
+		DOUBLE(DoubleFlag.class),
+		INTEGER(IntegerFlag.class),
+		STRING(StringFlag.class);
+
+		Class<?> flagClass;
+
+		FlagType(Class<?> flagClass) {
+			this.flagClass = flagClass;
+		}
+	}
+
+	public static Class<?> GetFlagClass(String flagType, Target t) {
+		try {
+			return FlagType.valueOf(flagType.toUpperCase()).flagClass;
+		} catch (IllegalArgumentException ex) {
+			throw new CREIllegalArgumentException("Invalid flag type: " + flagType + ". Must be one of: "
+					+ StringUtils.Join(FlagType.values(), ", ", ", or "), t);
+		}
+	}
+
 	public static boolean TestState(ApplicableRegionSet set, MCPlayer p, StateFlag flag) {
 		if(p == null) {
 			return set.testState(null, flag);


### PR DESCRIPTION
I'd like some thoughts on this, particularly so I'm not coding it into a corner here.

This is a primitive implementation that only implements four of the simplest flag types so far. Flags in WorldGuard are limited to registering only at startup. It'll throw an exception otherwise. I think that should be sufficient?

This should be expandable, including supporting other builtin flag classes (particularly StateFlag) or creating our own flag classes for custom input validations and such. Also should be expandable for region groups.

I'm not sure how best to implement the arguments for some of the more complex types. Some flags can have default values and/or default groups (and something like Set can be a list of one of the other types). It's possible we'd need to support an array for the third argument instead of declaring a certain order like sk_register_flag('name', 'STRING', 'MEMBERS', 'default string'). This is especially weird because not all flag types support all of these arguments.